### PR TITLE
docs: Fix simple typo, isntance -> instance

### DIFF
--- a/hooks/iscroll_hook.js
+++ b/hooks/iscroll_hook.js
@@ -13,7 +13,7 @@ function IScrollMenu(container, scrollMenuOptions, iScrollOptions){
     //hide iscroll scrollbars if scrollbarVisible is not set to true
     if(!scrollMenuOptions.scrollbarVisible && !ScrollMenu.defaults.scrollbarVisible) iScrollOptions.scrollbars = false;
     
-    //initiate both plugins and keep there isntance to return
+    //initiate both plugins and keep there instance to return
     var iScrollInst = new IScroll(container, iScrollOptions),
         scrollMenuInst = ScrollMenu(container, scrollMenuOptions);
 

--- a/hooks/nicescroll_hook.js
+++ b/hooks/nicescroll_hook.js
@@ -15,7 +15,7 @@ function niceScrollMenu(container, scrollMenuOptions, niceScrollOptions){
     //hide nicescroll scrollbars if scrollbarVisible is not set to true
     if(!scrollMenuOptions.scrollbarVisible && !ScrollMenu.defaults.scrollbarVisible) niceScrollOptions.autohidemode = "hidden";
     
-    //initiate both plugins and keep there isntance to return
+    //initiate both plugins and keep there instance to return
     var niceScrollInst = container.niceScroll(niceScrollOptions),
         scrollMenuInst = ScrollMenu(container, scrollMenuOptions);
 


### PR DESCRIPTION
There is a small typo in hooks/iscroll_hook.js, hooks/nicescroll_hook.js.

Should read `instance` rather than `isntance`.

